### PR TITLE
Aylar- Babaei-DATA.JSON-HW

### DIFF
--- a/Aylar-GroupABM.json
+++ b/Aylar-GroupABM.json
@@ -1,0 +1,8 @@
+{ "data" : [
+  {"weigt" : 150.06, "date" : "April 1, 2015" },
+            {"weight" : 150.24, "date" : "April 2, 2015" },
+            {"weight" : 148.99, "date" : "April 3, 2015" },
+            {"weight" : 149.40, "date" : "April 4, 2015" },
+  ]
+}
+  

--- a/json-hw-ababaei
+++ b/json-hw-ababaei
@@ -1,0 +1,17 @@
+
+
+{
+"genes": [{
+"accession": "KJ891170",
+"name": "Synthetic construct Homo sapiens clone ccsbBroadEn_00564 FGR gene",
+"length": 1719
+}, {
+"accession": "NC_008558",
+"name": "Blackberry virus Y",
+"length": 10851
+}, {
+"accession": "CR542175",
+"name": "Homo sapiens full open reading frame cDNA clone RZPDo834B1024D for gene CYCS ",
+"length": 318
+}]
+}


### PR DESCRIPTION
{"header":{"type":"esummary","version":"0.3"},"result":{"uids":["28864546","28800981","29336629"],"28864546":{"uid":"28864546","term":"28864546","caption":"AY207443","title":"Homo sapiens alpha hemoglobin (HBZP) pseudogene 3' UTR/AluJo repeat breakpoint junction","extra":"gi|28864546|gb|AY207443.1|","gi":28864546,"createdate":"2003/03/05","updatedate":"2003/03/05","flags":"","taxid":9606,"slen":491,"biomol":"genomic","moltype":"dna","topology":"linear","sourcedb":"insd","segsetsize":"","projectid":"0","genome":"","subtype":"chromosome|map|tissue_type|note","subname":"16|16p13.3|fetal liver|similar to the sequence deposited in GenBank Accession Number AE006462","assemblygi":"","assemblyacc":"","tech":"","completeness":"","geneticcode":"1","strand":"ds","organism":"human","strain":"","biosample":"","statistics":[{"type":"Length","count":491},{"type":"Length","subtype":"literal","count":491},{"type":"all","count":4},{"type":"blob_size","count":2390},{"type":"gene","count":1},{"type":"gene","subtype":"Gene/pseudo","count":1},{"type":"imp","count":2},{"type":"imp","subtype":"misc_recomb","count":1},{"type":"imp","subtype":"repeat_region","count":1},{"type":"org","count":1},{"type":"pub","count":2},{"type":"pub","subtype":"unpublished","count":1},{"source":"all","type":"Length","count":491},{"source":"all","type":"all","count":5},{"source":"all","type":"blob_size","count":2390},{"source":"all","type":"gene","count":2},{"source":"all","type":"imp","count":2},{"source":"all","type":"org","count":1},{"source":"all","type":"pub","count":2},{"source":"xref","type":"all","count":1},{"source":"xref","type":"gene","count":1},{"source":"xref","type":"gene","subtype":"Gene","count":1}],"properties":{"na":"1","value":"1"},"oslt":{"indexed":true,"value":"AY207443.1"},"accessionversion":"AY207443.1"},"28800981":{"uid":"28800981","term":"28800981","caption":"AY205604","title":"Homo sapiens hemochromatosis (HFE) mRNA, partial cds","extra":"gi|28800981|gb|AY205604.1|","gi":28800981,"createdate":"2003/03/03","updatedate":"2016/07/25","flags":"","taxid":9606,"slen":860,"biomol":"mRNA","moltype":"rna","topology":"linear","sourcedb":"insd","segsetsize":"","projectid":"0","genome":"","subtype":"chromosome|map|sex|cell_type","subname":"6|6p21.3|female|blood","assemblygi":"","assemblyacc":"","tech":"","completeness":"","geneticcode":"1","strand":"ss","organism":"human","strain":"","biosample":"","statistics":[{"type":"Length","count":860},{"type":"Length","subtype":"literal","count":860},{"type":"all","count":3},{"type":"blob_size","count":2494},{"type":"cdregion","count":1},{"type":"cdregion","subtype":"CDS","count":1},{"type":"gene","count":1},{"type":"gene","subtype":"Gene","count":1},{"type":"org","count":1},{"type":"pub","count":2},{"type":"pub","subtype":"unpublished","count":1},{"source":"CDS","type":"all","count":1},{"source":"CDS","type":"prot","count":1},{"source":"CDS","type":"prot","subtype":"Prot","count":1},{"source":"all","type":"Length","count":860},{"source":"all","type":"all","count":4},{"source":"all","type":"blob_size","count":2494},{"source":"all","type":"cdregion","count":1},{"source":"all","type":"gene","count":1},{"source":"all","type":"org","count":1},{"source":"all","type":"prot","count":1},{"source":"all","type":"pub","count":2}],"properties":{"na":"1","value":"1"},"oslt":{"indexed":true,"value":"AY205604.1"},"accessionversion":"AY205604.1"},"29336629":{"uid":"29336629","term":"29336629","caption":"Q50496","accessionversion":"Q50496.2","sourcedb":"swiss_prot","title":"RecName: Full=Sensor histidine kinase MtrB","extra":"gi|29336629|sp|Q50496.2|MTRB_MYCTU","gi":29336629,"createdate":"2003/03/25","updatedate":"2014/03/19","organism":"Mycobacterium tuberculosis","taxid":1773,"geneticcode":"11","subtype":"","subname":"","slen":567,"moltype":"aa","topology":"linear","completeness":"complete","biomol":"peptide","biosample":"","statistics":[{"type":"Length","count":567},{"type":"pub","count":9},{"type":"Length","subtype":"literal","count":567},{"type":"all","count":11},{"type":"gene","count":1},{"type":"prot","count":1},{"type":"region","count":7},{"type":"site","count":2}],"comment":"This sequence has been updated.","status":"replaced","replacedby":"P9WGK8","flags":"","properties":{"aa":"2","value":"2"},"oslt":{"indexed":false,"value":"Q50496.2"},"idgiclass":{"mol":"3","repr":"2","gi_state":"0","sat":"5","sat_key":"66319605","owner":"6","sat_name":"PROT","owner_name":"SP","defdiv":"SPT","length":"567","extfeatmask":"8"}}}}
